### PR TITLE
fix(front-api): invalidate user stats and media ratings queries on mutation success

### DIFF
--- a/apps/frontend/app/api/mediaRatings/useMediaRatingsApi.ts
+++ b/apps/frontend/app/api/mediaRatings/useMediaRatingsApi.ts
@@ -21,6 +21,7 @@ import {
   updateMediaRating,
 } from "~/api/mediaRatings/mediaRatingsApi"
 import { MediaRatingsApiQueryKeys } from "~/api/mediaRatings/mediaRatingsApiQueryKeys"
+import { UsersQueryKeys } from "~/api/users/usersApiQueryKeys"
 
 export function useGetMediaRatingByMediaIdApi(args: GetMediaRatingByMediaIdArgs) {
   return useQuery({
@@ -74,6 +75,14 @@ export function useCreateMediaRatingApi() {
     onSuccess: async (data: MediaRatingType) => {
       await Promise.all([
         queryClient.setQueryData([MediaRatingsApiQueryKeys.GET_BY_MEDA_ID, data.mediaId], data),
+        queryClient.invalidateQueries({
+          queryKey: [MediaRatingsApiQueryKeys.GET_ALL_BY_USER_ID],
+          refetchType: "all",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [UsersQueryKeys.STATS_BY_ID],
+          refetchType: "all",
+        }),
         queryClient.refetchQueries({
           queryKey: [MediaItemsQueryKeys.GET_BY_MEDIA_LIST_ID],
         }),
@@ -92,6 +101,14 @@ export function useUpdateMediaRatingApi() {
     onSuccess: async (data: MediaRatingType) => {
       await Promise.all([
         queryClient.setQueryData([MediaRatingsApiQueryKeys.GET_BY_MEDA_ID, data.mediaId], data),
+        queryClient.invalidateQueries({
+          queryKey: [MediaRatingsApiQueryKeys.GET_ALL_BY_USER_ID],
+          refetchType: "all",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [UsersQueryKeys.STATS_BY_ID],
+          refetchType: "all",
+        }),
         queryClient.refetchQueries({
           queryKey: [MediaItemsQueryKeys.GET_BY_MEDIA_LIST_ID],
         }),
@@ -109,6 +126,14 @@ export function useDeleteMediaRatingApi() {
       await Promise.all([
         queryClient.resetQueries({
           queryKey: [MediaRatingsApiQueryKeys.GET_BY_MEDA_ID, data.mediaId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [MediaRatingsApiQueryKeys.GET_ALL_BY_USER_ID],
+          refetchType: "all",
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [UsersQueryKeys.STATS_BY_ID],
+          refetchType: "all",
         }),
         queryClient.refetchQueries({
           queryKey: [MediaItemsQueryKeys.GET_BY_MEDIA_LIST_ID],


### PR DESCRIPTION
### Main problem

Profile ratings stayed stale after creating/updating/deleting a movie rating, so the user had to refresh the page to see the updated data.

### Current fix

Updated media rating mutations to:
* patch single media-rating cache immediately
* invalidate cached user-rating list queries
* invalidate cached user stats queries
* refresh related media list item cache

This keeps the rating write path in sync with the profile read path.

### Possible other fixes
* Use exact query keys for user-rating list invalidation instead of broad prefix invalidation
* Add refetchOnMount: true for profile rating queries so stale data is refreshed when the profile page is reopened
Remove refetchQueries([MediaItemsQueryKeys.GET_BY_MEDIA_LIST_ID]) if media list items are not actually impacted by rating changes

### Trade-offs
Current approach is safe and ensures correctness
It can be broader than necessary, causing extra refetches for all user-rating queries and stats queries
A more targeted implementation would be more efficient but slightly more complex to wire correctly

### Overall 

I provide a solution, but I'm not sure how you'd like to handle this problem properly 